### PR TITLE
Don't start os_mon processes for ermf-executor

### DIFF
--- a/rel/files/advanced.config
+++ b/rel/files/advanced.config
@@ -1,1 +1,10 @@
-[{riak_mesos_executor, []}].
+[
+    {riak_mesos_executor, []},
+    {os_mon,
+        [
+            {start_disksup, false},
+            {start_memsup, false},
+            {start_cpu_sup, false}
+        ]
+    }
+].


### PR DESCRIPTION
We don't really need these for the executor itself, so pulling in Drew's change.

/cc @drewkerrigan 
