### PR TITLE
Simplify 'make package' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,27 +63,5 @@ test-deps:
 ##
 .PHONY: package
 export PKG_VERSION PKG_ID PKG_BUILD BASE_DIR ERLANG_BIN REBAR OVERLAY_VARS RELEASE
-
-package.src: deps
-	mkdir -p package
-	rm -rf package/$(PKG_ID)
-	git archive --format=tar --prefix=$(PKG_ID)/ $(PKG_REVISION)| (cd package && tar -xf -)
-	${MAKE} -C package/$(PKG_ID) deps
-	mkdir -p package/$(PKG_ID)/priv
-	git --git-dir=.git describe --tags >package/$(PKG_ID)/priv/vsn.git
-	for dep in package/$(PKG_ID)/deps/*; do \
-             echo "Processing dep: $${dep}"; \
-             mkdir -p $${dep}/priv; \
-             git --git-dir=$${dep}/.git describe --tags >$${dep}/priv/vsn.git; \
-        done
-	find package/$(PKG_ID) -depth -name ".git" -exec rm -rf {} \;
-	tar -C package -czf package/$(PKG_ID).tar.gz $(PKG_ID)
-
-dist: package.src
-	cp package/$(PKG_ID).tar.gz .
-
-package: package.src
-	${MAKE} -C package -f $(PKG_ID)/deps/node_package/Makefile
-
-pkgclean: distclean
-	rm -rf package
+package: rel
+	-tar -C rel -czf riak_mesos_executor.tar.gz riak_mesos_executor/


### PR DESCRIPTION
@nickelization With this in place, you should be able to simply clone the repo and do `make package`, and it'll drop `riak_mesos_executor.tar.gz` in the directory.
