### PR TITLE
Correctly detect and report riak exit conditions to mesos

### DIFF
--- a/src/rme_lifeline.erl
+++ b/src/rme_lifeline.erl
@@ -1,0 +1,71 @@
+-module(rme_lifeline).
+
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([register/1]).
+-export([set_task_id/1]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-include_lib("erlang_mesos/include/mesos_pb.hrl").
+
+-record(state, {
+          task_id, %% TODO Fill in the appropriate type record
+          watching = [] :: list({reference(), pid()})
+         }).
+
+start_link() -> gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+set_task_id(TaskId) ->
+    gen_server:call(?MODULE, {set_task_id, TaskId}).
+
+register(Pid) ->
+    gen_server:call(?MODULE, {register, Pid}).
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_call({register, Pid}, _From, State) ->
+    #state{watching = W} = State,
+    Ref = erlang:monitor(process, Pid),
+    {reply, ok, State#state{watching = [ {Ref, Pid} | W ]}};
+handle_call({set_task_id, TaskId}, _From, State) ->
+    {reply, ok, State#state{task_id=TaskId}};
+handle_call(_Request, _From, State) -> Reply = ok, {reply, Reply, State}.
+
+handle_cast(_Msg, State) -> {noreply, State}.
+
+handle_info({'DOWN', MRef, process, MPid, Reason}, State) ->
+    lager:info("rme_lifeline saw process ~p die because ~p", [MPid, Reason]),
+    case lists:keysearch(MRef, 1, State#state.watching) of
+        {value, {MRef, MPid}} ->
+            %% I didn't watch my buddies die face down in the muck so that you... Ugh!
+            {stop, normal, State};
+        _ -> {noreply, State}
+    end;
+handle_info(_Info, State) -> {noreply, State}.
+
+terminate(Reason, #state{task_id=undefined}=State) ->
+    lager:warn("rme_lifeline terminating [~p] but no TaskId was set", [Reason]),
+    {stop, Reason, State};
+terminate(normal, #state{task_id=TaskId}=State) ->
+    lager:info("rme_lifeline: normal shutdown, sending TASK_FINISHED to master"),
+    TaskStatus = #'TaskStatus'{ task_id=TaskId, state='TASK_FINISHED' },
+    {ok, driver_running} = executor:sendStatusUpdate(TaskStatus),
+    {stop, normal, State};
+terminate(Reason, #state{task_id=TaskId}=State) ->
+    lager:error("rme_lifeline: abnormal shutdown [~p], sending TASK_FAILED to master", [Reason]),
+    TaskStatus = #'TaskStatus'{ task_id=TaskId, state='TASK_FAILED' },
+    {ok, driver_running} = executor:sendStatusUpdate(TaskStatus),
+    {stop, Reason, State};
+terminate(_Reason, _State) ->
+    %% TODO This is where we need to send a status update to mesos
+    ok.
+
+code_change(_OldVsn, State, _Extra) -> {ok, State}.

--- a/src/rme_sup.erl
+++ b/src/rme_sup.erl
@@ -28,6 +28,7 @@ start_link() ->
 
 init([]) ->
     ExecSup = {rnp_exec_sup, {rnp_exec_sup, start_link, []}, permanent, 300, supervisor, dynamic},
-    Mod = riak_mesos_executor,
-    Executor = {Mod, {Mod, start_link, []}, permanent, 300, worker, dynamic},
-    {ok, { {one_for_one, 5, 10}, [ExecSup, Executor]} }.
+    Lifeline = {rme_lifeline, {rme_lifeline, start_link, []}, permanent, 300, worker, dynamic},
+    Executor = {riak_mesos_executor, {riak_mesos_executor, start_link, []}, permanent, infinity, worker, dynamic},
+    %% Allow 0 restarts: this way, when rme_lifeline terminates, we bring down the application
+    {ok, { {one_for_one, 0, 1}, [ExecSup, Lifeline, Executor]} }.


### PR DESCRIPTION
By having rme_lifeline monitor rnp_sup_bridge (the process in charge of
the riak node), and having it terminate when that process dies (which happens
when the riak node stops for any reason - e.g. someone has run
'riak-mesos node remove --node $foo'), we can bring down the whole
executor cleanly (or not, if riak exited uncleanly) and report that status
to mesos as appropriate.
