### PR TITLE
Set ulimit for executor and riak

### DIFF
--- a/rel/files/ermf-executor.sh
+++ b/rel/files/ermf-executor.sh
@@ -17,6 +17,7 @@ main() {
     sed -i"" -e "/nodename/s/= .*@/= ${NODENAME}@/" riak_mesos_executor/etc/riak_mesos_executor.conf
 
     echo "Starting riak_mesos_executor..."
+    ulimit -n 65536 2>&1 > /dev/null
     riak_mesos_executor/bin/riak_mesos_executor console -noinput #-no_epmd
 }
 


### PR DESCRIPTION
Run ulimit 65536 before running riak, the simplest way possible.