### PR TITLE
Tidying up node stop/restart behaviour

### DIFF
--- a/src/riak_mesos_executor.erl
+++ b/src/riak_mesos_executor.erl
@@ -122,7 +122,8 @@ acknowledged(_ExecutorInfo, EventAcknowledged, #state{ack_dict = AckDict} = Stat
     {ok, state()}.
 framework_message(ExecutorInfo, #'Event.Message'{data = <<"finish">>},
                   State) ->
-    lager:debug("Force finishing riak node"),
+    lager:debug("Finishing riak node"),
+    ok = rme_rnp:stop(State#state.rnp_state),
     State1 = State#state{rnp_state = undefined},
     update_task_status(ExecutorInfo, 'TASK_FINISHED', State1);
 framework_message(_ExecutorInfo, EventMessage, State) ->

--- a/src/rme_lifeline.erl
+++ b/src/rme_lifeline.erl
@@ -4,7 +4,6 @@
 
 -export([start_link/0]).
 -export([register/1]).
--export([set_task_id/1]).
 
 -export([init/1,
          handle_call/3,
@@ -16,14 +15,10 @@
 -include_lib("erl_mesos/include/executor_protobuf.hrl").
 
 -record(state, {
-          task_id, %% TODO Fill in the appropriate type record
           watching = [] :: list({reference(), pid()})
          }).
 
 start_link() -> gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
-
-set_task_id(TaskId) ->
-    gen_server:call(?MODULE, {set_task_id, TaskId}).
 
 register(Pid) ->
     gen_server:call(?MODULE, {register, Pid}).
@@ -35,8 +30,6 @@ handle_call({register, Pid}, _From, State) ->
     #state{watching = W} = State,
     Ref = erlang:monitor(process, Pid),
     {reply, ok, State#state{watching = [ {Ref, Pid} | W ]}};
-handle_call({set_task_id, TaskId}, _From, State) ->
-    {reply, ok, State#state{task_id=TaskId}};
 handle_call(_Request, _From, State) -> Reply = ok, {reply, Reply, State}.
 
 handle_cast(_Msg, State) -> {noreply, State}.
@@ -46,26 +39,12 @@ handle_info({'DOWN', MRef, process, MPid, Reason}, State) ->
     case lists:keysearch(MRef, 1, State#state.watching) of
         {value, {MRef, MPid}} ->
             %% I didn't watch my buddies die face down in the muck so that you... Ugh!
-            {stop, normal, State};
+            {stop, Reason, State};
         _ -> {noreply, State}
     end;
 handle_info(_Info, State) -> {noreply, State}.
 
-terminate(Reason, #state{task_id=undefined}=State) ->
-    lager:warn("rme_lifeline terminating [~p] but no TaskId was set", [Reason]),
-    {stop, Reason, State};
-terminate(normal, #state{task_id=TaskId}=State) ->
-    lager:info("rme_lifeline: normal shutdown, sending TASK_FINISHED to master"),
-    TaskStatus = #'TaskStatus'{ task_id=TaskId, state='TASK_FINISHED' },
-    {ok, driver_running} = executor:sendStatusUpdate(TaskStatus),
-    {stop, normal, State};
-terminate(Reason, #state{task_id=TaskId}=State) ->
-    lager:error("rme_lifeline: abnormal shutdown [~p], sending TASK_FAILED to master", [Reason]),
-    TaskStatus = #'TaskStatus'{ task_id=TaskId, state='TASK_FAILED' },
-    {ok, driver_running} = executor:sendStatusUpdate(TaskStatus),
-    {stop, Reason, State};
-terminate(_Reason, _State) ->
-    %% TODO This is where we need to send a status update to mesos
-    ok.
+terminate(Reason, #state{}=State) ->
+    {stop, Reason, State}.
 
 code_change(_OldVsn, State, _Extra) -> {ok, State}.

--- a/src/rme_rnp.erl
+++ b/src/rme_rnp.erl
@@ -140,8 +140,8 @@ force_stop(#state{exes=Exes, task_id=TaskID}=_St) ->
 
 %% TODO Bound to 127.0.0.1 because we should only need to connect to our own ErlPMD
 start_erlpmd(Port) ->
-    %% TODO Maybe there's a nicer way to do this
-    erlpmd_sup:start_link([{0,0,0,0}], Port, rme_erlpmd_store, []).
+    ErlPMDSup = {erlpmd_sup, {erlpmd_sup, start_link, [[{0,0,0,0}], Port, rme_erlpmd_store, []]}, permanent, 300, supervisor, dynamic},
+    supervisor:start_child(rme_sup, ErlPMDSup).
 
 serialise_coordinated_data(#taskdata{}=TD) ->
     %% TODO can't we just use the original TDKV?

--- a/src/rme_rnp.erl
+++ b/src/rme_rnp.erl
@@ -169,7 +169,7 @@ set_coordinated_child(#'TaskID'{}=TaskId, SerialisedData) ->
     {ok, _Child, _} = set_ephemeral_child(CoordinatedNodes, TaskId#'TaskID'.value, SerialisedData).
 
 set_ephemeral_child(Parent, ChildName, ChildData) ->
-    % Default to a total of 100 + 200 + 400 + 800 + 1600 = 3100ms
+    % Default to a total of 25500ms (100, 200 .. 12800)
     set_ephemeral_child(Parent, ChildName, ChildData, 100, 12800).
 
 set_ephemeral_child(_, _, _, Delay, DelayLimit) when DelayLimit < Delay ->

--- a/src/rme_rnp.erl
+++ b/src/rme_rnp.erl
@@ -58,8 +58,6 @@ setup(#'TaskInfo'{}=TaskInfo) ->
        resources=Resources,
        data=RawTData
       }=TaskInfo,
-    % Register the task_id with rme_lifeline so that it can send status updates
-    ok = rme_lifeline:set_task_id(TaskId),
     State0 = process_resources(Resources),
     TD = parse_taskdata(RawTData),
     #state{ports=[ErlPMDPort|Ps]}=State1 = filter_ports(TD, State0),

--- a/src/rme_rnp.erl
+++ b/src/rme_rnp.erl
@@ -98,8 +98,7 @@ start(#state{}=State) ->
            exes=Exes} = State,
     % Start ErlPMD
     lager:info("Starting ErlPMD on port ~s~n", [integer_to_list(Port)]),
-    {ok, ErlPMD} = start_erlpmd(Port),
-    State1 = State#state{exes=[ErlPMD | Exes]},
+    {ok, _} = start_erlpmd(Port),
     %% TODO These should be coming from TaskInfo
     Location = "../root/riak",
     Script = "bin/riak",
@@ -107,7 +106,7 @@ start(#state{}=State) ->
     %% TODO This whole process management needs ironing out
     case rnp_exec_sup:start_cmd(Location, Command, [{env, [{"ERL_EPMD_PORT", integer_to_list(Port)}]}]) of
         {ok, Pid, _OSPid} ->
-            State2 = State1#state{exes=[Pid | (State1#state.exes) ]},
+            State2 = State#state{exes=[Pid | Exes]},
             %% TODO These arguments are practical but they make little sense.
             case wait_for_healthcheck(fun healthcheck/1, "../root/riak", 60000) of
                 ok ->


### PR DESCRIPTION
There were some inconsistencies and generally unsavoury behaviours surrounding an executor stopping for restart.

 - `rme_lifeline` was still trying to send status updates the old way. Later, we may even be able to remove this process altogether.
 - ZK's "ephemeral" data is not quite as ephemeral as one would hope: now we have a lengthy backoff/retry process if it still exists, and explicitly delete it when stopping deliberately.
 - `erlpmd` was started by calling `erlpmd_sup:start_link` from the executor process itself: now we add it to the top-level `rme_sup` with `supervisor:start_child`
 - we were trying to treat `erlpmd_sup` as an `erlexec` process on shutdown, causing an erroneous crash. Don't.
 - we had accidentally deleted the call to stop the riak node when cleanly finishing the executor.