### PR TITLE
Add riak node network interface option

### DIFF
--- a/src/rme_config.erl
+++ b/src/rme_config.erl
@@ -1,0 +1,61 @@
+-module(rme_config).
+
+-export([get_value/2, get_value/3,
+         convert_value/2]).
+
+-spec get_value(atom(), term()) -> term().
+get_value(Key, Default) ->
+    case get_env_value(Key) of
+        false ->
+            application:get_env(rms, Key, Default);
+        Value ->
+            Value
+    end.
+
+-spec get_value(atom(), term(), atom()) -> term().
+get_value(Key, Default, Type) ->
+    case get_value(Key, Default) of
+        Default ->
+            Default;
+        Value ->
+            convert_value(Value, Type)
+    end.
+
+%% Internal functions.
+
+-spec convert_value(term(), atom()) -> term().
+convert_value(Value, number) when is_list(Value) ->
+    try
+        list_to_float(Value)
+    catch 
+        error:badarg -> list_to_integer(Value)
+    end;
+convert_value(Value, integer) when is_list(Value) ->
+    list_to_integer(Value);
+convert_value(Value, float) when is_list(Value) ->
+    list_to_float(Value);
+convert_value(Value, boolean) when is_list(Value) ->
+    list_to_atom(Value);
+convert_value(Value, atom) when is_list(Value) ->
+    list_to_atom(Value);
+convert_value(Value, binary) when is_list(Value) ->
+    list_to_binary(Value);
+convert_value(Value, html_string) when is_binary(Value) ->
+    unescape_html(binary_to_list(Value));
+convert_value(Value, html_string) when is_list(Value) ->
+    unescape_html(Value);
+convert_value(Value, _Type) ->
+    Value.
+
+-spec unescape_html(string()) -> string().
+unescape_html([]) -> [];
+unescape_html("&quot;"++Rest) -> "\"" ++ unescape_html(Rest);
+unescape_html("&lt;" ++ Rest) -> "<" ++ unescape_html(Rest);
+unescape_html("&gt;" ++ Rest) -> ">" ++ unescape_html(Rest);
+unescape_html("&amp;"++ Rest) -> "&" ++ unescape_html(Rest);
+unescape_html([C | Rest]) -> [ C | unescape_html(Rest) ].
+
+-spec get_env_value(atom()) -> string() | false.
+get_env_value(Key) ->
+    Key1 = "RIAK_MESOS_" ++ string:to_upper(atom_to_list(Key)),
+    os:getenv(Key1).

--- a/src/rme_rnp.erl
+++ b/src/rme_rnp.erl
@@ -68,13 +68,13 @@ setup(#'TaskInfo'{}=TaskInfo) ->
                                        TD#taskdata.framework_name),
     NodeIface = rme_config:get_value(node_iface, "", string),
     %% TODO What if the list comp below returns an empty list
-    [NodeBindIP|_] =
-        case NodeIface of
-            [] -> [ "0.0.0.0" ];
-            Iface ->
-                {ok, IFs} = inet:getifaddrs(),
-                [inet:ntoa(proplists:get_value(addr, Props, {0, 0, 0, 0}))
-                 || {IF, Props} <- IFs, IF == Iface]
+    {ok, IFs} = inet:getifaddrs(),
+    IfaceIPs = [inet:ntoa(proplists:get_value(addr, Props, {0, 0, 0, 0}))
+                || {IF, Props} <- IFs, IF == NodeIface],
+    NodeBindIP =
+        case IfaceIPs of
+            [] -> "0.0.0.0";
+            [IP|_] -> IP
         end,
     % TODO: This location should come from the TaskInfo somehow
     % Probably from one of the #'Resource' records?

--- a/src/rme_rnp.erl
+++ b/src/rme_rnp.erl
@@ -67,7 +67,6 @@ setup(#'TaskInfo'{}=TaskInfo) ->
     {ok, MDMgr} = mesos_metadata_manager:start_link(TD#taskdata.zookeepers,
                                        TD#taskdata.framework_name),
     NodeIface = rme_config:get_value(node_iface, "", string),
-    %% TODO What if the list comp below returns an empty list
     {ok, IFs} = inet:getifaddrs(),
     IfaceIPs = [inet:ntoa(proplists:get_value(addr, Props, {0, 0, 0, 0}))
                 || {IF, Props} <- IFs, IF == NodeIface],

--- a/src/rme_rnp.erl
+++ b/src/rme_rnp.erl
@@ -66,11 +66,21 @@ setup(#'TaskInfo'{}=TaskInfo) ->
     {struct, TDKV} = mochijson2:decode(RawTData),
     {ok, MDMgr} = mesos_metadata_manager:start_link(TD#taskdata.zookeepers,
                                        TD#taskdata.framework_name),
+    NodeIface = rme_config:get_value(node_iface, "", string),
+    %% TODO What if the list comp below returns an empty list
+    [NodeBindIP|_] =
+        case NodeIface of
+            [] -> [ "0.0.0.0" ];
+            Iface ->
+                {ok, IFs} = inet:getifaddrs(),
+                [inet:ntoa(proplists:get_value(addr, Props, {0, 0, 0, 0}))
+                 || {IF, Props} <- IFs, IF == Iface]
+        end,
     % TODO: This location should come from the TaskInfo somehow
     % Probably from one of the #'Resource' records?
     ok = configure("../root/riak/etc/riak.conf",
                    config_uri(TD, "/config"),
-                   TDKV),
+                   [{bindaddress, NodeBindIP} | TDKV]),
     ok = configure("../root/riak/etc/advanced.config",
                    config_uri(TD, "/advancedConfig"),
                    [{cepmdport, State2#state.cepmd_port}]),


### PR DESCRIPTION
When rendering the `riak.conf` template, add an extra template var: `bindaddress`. This template variable will be set to either: 
 - `"0.0.0.0"` by default
 - the IP associated with a network interface passed into the executor environment via the `RIAK_MESOS_NODE_IFACE` env var: if there is no matching interface, the default value is used.

This PR also lays the groundwork for the executor to pull configuration from its environment, identically to the scheduler.