### PR TITLE
Relocatable package support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ define build-patches
 	cd packages && echo "$(BASE_DIR)/packages/$(PATCH_PKGNAME)" > patches_local.txt
 endef
 
+patches: rel-patches root-patches
+
 root-patches: RIAK_BASE = root
 root-patches:
 	$(call build-patches)

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ root-patches: RIAK_BASE = root
 root-patches:
 	$(call build-patches)
 
-rel-patches: RIAK_BASE = rel
+rel-patches: RIAK_BASE = .
 rel-patches: PATCHNAME = riak_erlpmd_patches-rel
 rel-patches:
 	$(call build-patches)

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,10 @@ test-deps:
 	-cp test-deps/sampler.tar.gz test/rnp_SUITE_data/
 	-cp test-deps/sampler.tar.gz test/rnp_sup_bridge_SUITE_data/
 
+##
+## Packaging targets
+##
+RIAK_BASE ?= root
 define build-patches
 	$(MAKE) RIAK_BASE=$(RIAK_BASE) -C patches clean all prepare
 	-echo "Creating patches/"$(PATCH_PKGNAME)
@@ -105,10 +109,6 @@ rel-patches: PATCHNAME = riak_erlpmd_patches-rel
 rel-patches:
 	$(call build-patches)
 
-##
-## Packaging targets
-##
-RIAK_BASE ?= root
 tarball: rel retarball
 retarball: relx patches
 	-echo "Creating packages/"$(PKGNAME)

--- a/patches/Makefile
+++ b/patches/Makefile
@@ -3,6 +3,8 @@ ERLC=erlc
 ESRC=src
 EBIN=ebin
 
+RIAK_BASE ?= root
+
 ERL_COMPILE_FLAGS += -I include -Werror
 
 .NOTPARALLEL:
@@ -11,9 +13,10 @@ all:
 	$(ERLC) $(ERL_COMPILE_FLAGS) -o$(EBIN) $(ESRC)/erl_epmd.erl
 
 clean:
-	rm -f $(EBIN)/*.beam
+	-rm -f $(EBIN)/*.beam
+	-rm -rf sandbox/*
 
 prepare:
-	-mkdir -p root/riak/lib/basho-patches
-	-mv $(EBIN)/* root/riak/lib/basho-patches/
+	-mkdir -p sandbox/$(RIAK_BASE)/riak/lib/basho-patches
+	-mv $(EBIN)/* sandbox/$(RIAK_BASE)/riak/lib/basho-patches/
 

--- a/src/rme_rnp.erl
+++ b/src/rme_rnp.erl
@@ -87,7 +87,7 @@ setup(#'TaskInfo'{}=TaskInfo) ->
     ok = configure(filename:join([Location, "etc/advanced.config"]),
                    config_uri(TD, "/advancedConfig"),
                    [{cepmdport, State2#state.cepmd_port}]),
-    ok = append_controlled_config("../root/riak/etc/riak.conf",
+    ok = append_controlled_config(filename:join([Location, "etc/riak.conf"]),
                                   "priv/riak-mesos.conf",
                                   [{bindaddress, NodeBindIP},
                                    {data_dir, "../../data"}

--- a/src/rme_rnp.erl
+++ b/src/rme_rnp.erl
@@ -69,7 +69,8 @@ setup(#'TaskInfo'{}=TaskInfo) ->
     % Remove the "." components
     RootClean = lists:filter(fun(".") -> false; (_) -> true end, RootComponents),
     RootDepth = length(filename:split(RootClean)),
-    DataDir = filename:join(lists:duplicate(RootDepth, "..")),
+    % From Riak's PoV there's an extra level, so +1 
+    DataDir = filename:join(lists:duplicate(RootDepth + 1, "..") ++ ["data"]),
     #state{ports=[ErlPMDPort|Ps]}=State1 = filter_ports(TD, State0),
     State2 = State1#state{cepmd_port=ErlPMDPort, ports=Ps},
     %% TODO There are cleaner ways to wrangle JSON in erlang

--- a/src/rme_rnp.erl
+++ b/src/rme_rnp.erl
@@ -19,7 +19,7 @@
          cluster_name     :: string(),
          uri              :: string(),
          host             :: string(),
-         root_volume      :: string(),
+         riak_root_path   :: string(),
          use_super_chroot :: boolean(),
          http_port        :: non_neg_integer(),
          pb_port          :: non_neg_integer(),
@@ -50,7 +50,7 @@
 %%   PBPort:31346
 %%   HandoffPort:0
 %%   DisterlPort:31347
-%%   RootVolume:root
+%%   RiakRootPath:root
 %% }
 
 setup(#'TaskInfo'{}=TaskInfo) ->
@@ -62,7 +62,7 @@ setup(#'TaskInfo'{}=TaskInfo) ->
       }=TaskInfo,
     State0 = process_resources(Resources),
     TD = parse_taskdata(RawTData),
-    Root = TD#taskdata.root_volume,
+    Root = TD#taskdata.riak_root_path,
     Location = filename:join(["..", Root, "riak"]),
     #state{ports=[ErlPMDPort|Ps]}=State1 = filter_ports(TD, State0),
     State2 = State1#state{cepmd_port=ErlPMDPort, ports=Ps},
@@ -117,7 +117,7 @@ start(#state{}=State) ->
     % Start ErlPMD
     lager:info("Starting ErlPMD on port ~s~n", [integer_to_list(Port)]),
     {ok, _} = start_erlpmd(Port),
-    Root = Taskdata#taskdata.root_volume,
+    Root = Taskdata#taskdata.riak_root_path,
     Location = filename:join(["..", Root, "riak"]),
     Script = "bin/riak",
     Command = [Script, "console", "-noinput", "-epmd_port", integer_to_list(Port)],
@@ -319,7 +319,7 @@ parse_taskdata(JSON) when is_binary(JSON) ->
        cluster_name     = binary_to_list(proplists:get_value(<<"ClusterName">>, Data)),
        uri              = binary_to_list(proplists:get_value(<<"URI">>, Data)),
        host             = binary_to_list(proplists:get_value(<<"Host">>, Data)),
-       root_volume      = binary_to_list(proplists:get_value(<<"RootVolume">>, Data, <<"root">>)),
+       riak_root_path   = binary_to_list(proplists:get_value(<<"RiakRootPath">>, Data, <<"root">>)),
        use_super_chroot = proplists:get_value(<<"UseSuperChroot">>, Data),
        http_port        = proplists:get_value(<<"HTTPPort">>, Data),
        pb_port          = proplists:get_value(<<"PBPort">>, Data),


### PR DESCRIPTION
This adds the creation of an extra archive when building the patches archive - one which is compatible with the official riak rel builds which have no parent dir.